### PR TITLE
adding in serialize call to serialize data using the Hstore serializer

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,8 @@
 class Product < ActiveRecord::Base
   belongs_to :user
 
+  serialize :data, ActiveRecord::Coders::Hstore
+
   def as_json(options = {})
     {:name => name, :data => data}
   end


### PR DESCRIPTION
This fixes issues where the hash being sent in isn't getting serialized before being created. This causes an error on any hash you attempt to save. See issue https://github.com/heroku/hstore_example/issues/2
