### PR TITLE
Fix application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,15 @@
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.11'
-
-# Bundle edge Rails instead:
-# gem 'rails', :git => 'git://github.com/rails/rails.git'
+gem 'rails', '3.2.1'
 
 gem 'pg'
 
 gem 'dalli'
-gem 'activerecord-postgres-hstore'
+gem 'activerecord-postgres-hstore', "0.3.0"
 
-
-# Gems used only for assets and not required
-# in production environments by default.
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
-
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  # gem 'therubyracer'
-
   gem 'uglifier', '>= 1.0.3'
 end
 
@@ -28,18 +18,3 @@ gem 'jquery-rails'
 gem 'devise',                  "~> 2.0.4"
 
 gem "twitter-bootstrap-rails", "~> 2.0.1.0"
-
-# To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
-
-# To use Jbuilder templates for JSON
-# gem 'jbuilder'
-
-# Use unicorn as the web server
-# gem 'unicorn'
-
-# Deploy with Capistrano
-# gem 'capistrano'
-
-# To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'


### PR DESCRIPTION
TLDR; this fixes everything.

Unfortunately, updating Rails 3.2.1 to 3.2.11 blindly breaks show routes.  I'm guessing this is partially because the Journey router updated, among other significant changes in the 3.2.x release.

Also, there seems to have been some breaking changes in `activerecord-postgres-hstore`, so I locked it to what was in your checked-in Gemfile.  Including the latest version of this gem will break `schema.rb`.
